### PR TITLE
fear(flag): integrate `--silent` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,31 @@
-                    
-        _________ .__                        __                        __    
-        \_   ___ \|  |   ____ _____ ________/  |_____________    ____ |  | __
-        /    \  \/|  | _/ __ \\__  \\_  __ \   __\_  __ \__  \ _/ ___\|  |/ /
-        \     \___|  |_\  ___/ / __ \|  | \/|  |  |  | \// __ \\  \___|    < 
-         \______  /____/\___  >____  /__|   |__|  |__|  (____  /\___  >__|_ \
-                \/          \/     \/                        \/     \/     \/
-                    
+<pre>
+ _________ .__                        __                        __    
+ \_   ___ \|  |   ____ _____ ________/  |_____________    ____ |  | __
+ /    \  \/|  | _/ __ \\__  \\_  __ \   __\_  __ \__  \ _/ ___\|  |/ /
+ \     \___|  |_\  ___/ / __ \|  | \/|  |  |  | \// __ \\  \___|    < 
+  \______  /____/\___  >____  /__|   |__|  |__|  (____  /\___  >__|_ \
+         \/          \/     \/                        \/     \/     \/ 
+</pre>
+
 # cleartrack CLI
+
+[![PyPI version](https://img.shields.io/pypi/v/cleartrack.svg)](https://pypi.org/project/cleartrack)
+[![Downloads](https://img.shields.io/pypi/dm/cleartrack.svg)](https://pypi.org/project/cleartrack)
+[![Release](https://img.shields.io/github/v/release/anilrajrimal1/cleartrack)](https://github.com/anilrajrimal1/cleartrack/releases)
+[![License](https://img.shields.io/github/license/anilrajrimal1/cleartrack)](LICENSE)
 
 Track your terminal `clear` habits with style.
 
 ## Features
-- Replaces your `clear` command
-- Logs every use
-- `--stats`, `--reset`, and `--ascii` modes
-- Easily installed via `pip`
 
-## Example
+- Replaces your `clear` command
+- Logs every use locally
+- `--silent`, `--stats`, `--reset`, and `--ascii` flags
+- Easily installable via `pip`
+- Fun + productive tracking your random clear hitting habit
+
+## 📸 Example
+
 ```bash
 $ clear
 [🧹] Cleared 69 times.
@@ -25,33 +34,53 @@ $ clear --stats
 [🧹] You have cleared your terminal 69 times. Keep it clean!
 ```
 
+---
+
 ## Installation
+
 ```bash
 pip install cleartrack
 ```
-Add this to your `.bashrc` / `.zshrc`:
+
+Then add this to your `.bashrc`, `.zshrc`, or `.config/fish/config.fish`:
+
 ```bash
 alias clear="cleartrack"
 ```
 
-## Usage
+Reload your shell config:
 ```bash
-clear           # clears screen and shows counter
-clear --stats   # show counter without clearing
-clear --reset   # reset the counter to 0
-clear --ascii   # show some fun ascii art
+source ~/.zshrc  # or ~/.bashrc
 ```
 
-## 👺 Developer Mode
+---
+
+## Usage
+
+```bash
+clear            # Clears screen + increments counter
+clear --silent   # no output, just logs for tracking
+clear --stats    # Show counter without clearing
+clear --reset    # Reset the counter to 0
+clear --ascii    # Show some fun ASCII art
+```
+
+---
+
+## Developer Mode
+
 ```bash
 git clone https://github.com/anilrajrimal1/cleartrack.git
 cd cleartrack
 pip install -e .
 ```
 
-## 🔖 License
-MIT
+---
+
+## 📄 License
+
+MIT © [Anil Raj Rimal](https://github.com/anilrajrimal1)
 
 ---
 
-Clear the noise. Count the habit. `cleartrack`.
+> Clear the noise. Count the habit. — `cleartrack`

--- a/cleartrack/cli.py
+++ b/cleartrack/cli.py
@@ -20,13 +20,13 @@ def save_count(count):
 
 def log_usage():
     with open(LOG_FILE, "a") as f:
-        f.write(f"{datetime.now().isoformat()}\n")
+        f.write(f"{datetime.now().isoformat()}\\n")
 
 def print_count(count, stats_mode=False):
     if stats_mode:
-        print(f"\033[92m[🧹] You have cleared your terminal {count} times. Keep it clean!\033[0m")
+        print(f"\\033[92m[🧹] You have cleared your terminal {count} times. Keep it clean!\\033[0m")
     else:
-        print(f"\033[92m[🧹] Cleared {count} times.\033[0m")
+        print(f"\\033[92m[🧹] Cleared {count} times.\\033[0m")
 
 def print_ascii():
     print(r"""
@@ -54,12 +54,16 @@ def main():
         print_ascii()
         return
 
+    silent = "--silent" in args
+
     count = get_count() + 1
     save_count(count)
     log_usage()
 
     subprocess.run(["clear"])
-    print_count(count, stats_mode=False)
+
+    if not silent:
+        print_count(count, stats_mode=False)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
# Add `--silent` flag to suppress output
- Implement `--silent` option to clear terminal and increment count without printing messages.
- Update README with usage instructions for `--silent`.
- Useful for scripting and quiet operation.
- closes issue #1 